### PR TITLE
Streamline prototype CI

### DIFF
--- a/.github/workflows/cd-deploy-nodes-gcp.patch-external.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.patch-external.yml
@@ -43,3 +43,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'
+
+  get-disk-name:
+    name: Get disk name
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "Skipping job on fork"'

--- a/.github/workflows/cd-deploy-nodes-gcp.patch-external.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.patch-external.yml
@@ -1,7 +1,7 @@
 # Workflow patches for skipping Google Cloud CD deployments on PRs from external repositories.
 name: Deploy Nodes to GCP
 
-# Run on PRs from external repositories, let them pass, and then Mergify will check them.
+# Run on PRs from external repositories, let them pass, and then GitHub's Merge Queue will check them.
 # GitHub doesn't support filtering workflows by source branch names, so we have to do it for each
 # job.
 on:
@@ -13,10 +13,16 @@ on:
 # `cd-deploy-nodes-gcp.patch-external.yml` must be kept in sync.
 jobs:
   # We don't patch the testnet job, because testnet isn't required to merge (it's too unstable)
+  get-disk-name:
+    name: Get disk name
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "Skipping job on fork"'
+
   build:
     name: Build CD Docker / Build images
     # Only run on PRs from external repositories, skipping ZF branches and tags.
-    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'
@@ -44,8 +50,3 @@ jobs:
     steps:
       - run: 'echo "Skipping job on fork"'
 
-  get-disk-name:
-    name: Get disk name
-    runs-on: ubuntu-latest
-    steps:
-      - run: 'echo "Skipping job on fork"'

--- a/.github/workflows/cd-deploy-nodes-gcp.patch.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.patch.yml
@@ -52,3 +52,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
+
+  get-disk-name:
+    name: Get disk name
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -1,6 +1,6 @@
 # Google Cloud node deployments and tests that run when Rust code or dependencies are modified,
 # but only on PRs from the ZcashFoundation/zebra repository.
-# (External PRs are tested/deployed by mergify.) 
+# (External PRs are tested/deployed by GitHub's Merge Queue.) 
 #
 # 1. `versioning`: Extracts the major version from the release semver. Useful for segregating instances based on major versions.
 # 2. `build`: Builds a Docker image named `zebrad` with the necessary tags derived from Git.
@@ -27,6 +27,9 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
+  merge_group:
+    types: [ checks_requested ]
+
   workflow_dispatch:
     inputs:
       network:
@@ -141,15 +144,29 @@ jobs:
         id: set
         run: echo "major_version=${{ steps.get.outputs.result }}" >> "$GITHUB_OUTPUT"
 
+  # Finds a cached state disk for zebra
+  #
+  # Passes the disk name to subsequent jobs using `cached_disk_name` output
+  #
+  get-disk-name:
+    name: Get disk name
+    uses: ./.github/workflows/sub-find-cached-disks.yml
+    # Skip PRs from external repositories, let them pass, and then GitHub's Merge Queue will check them.
+    # This workflow also runs on release tags, the event name check will run it on releases.
+    if: ${{ (!startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork) && !inputs.no_cached_disk }}
+    with:
+      network: ${{ inputs.network || vars.ZCASH_NETWORK }}
+      disk_prefix: zebrad-cache
+      disk_suffix: ${{ inputs.cached_disk_type || 'tip' }}
+      prefer_main_cached_state: ${{ inputs.prefer_main_cached_state || (github.event_name == 'push' && github.ref_name == 'main' && true) || false }}
+
   # Each time this workflow is executed, a build will be triggered to create a new image
   # with the corresponding tags using information from Git
   #
   # The image will be commonly named `zebrad:<short-hash | github-ref | semver>`
   build:
     name: Build CD Docker
-    # Skip PRs from external repositories, let them pass, and then Mergify will check them.
-    # This workflow also runs on release tags, the event name check will run it on releases.
-    if: ${{ !startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork }}
+    needs: get-disk-name
     uses: ./.github/workflows/sub-build-docker-image.yml
     with:
       dockerfile_path: ./docker/Dockerfile
@@ -196,20 +213,6 @@ jobs:
       grep_patterns: '-e "loaded zebrad config.*config_path.*=.*v1.0.0-rc.2.toml"'
       test_variables: '-e NETWORK -e ZEBRA_CONF_PATH="zebrad/tests/common/configs/v1.0.0-rc.2.toml"'
       network: ${{ inputs.network || vars.ZCASH_NETWORK }}
-
-  # Finds a cached state disk for zebra
-  #
-  # Passes the disk name to subsequent jobs using `cached_disk_name` output
-  #
-  get-disk-name:
-    name: Get disk name
-    uses: ./.github/workflows/sub-find-cached-disks.yml
-    if: ${{ !inputs.no_cached_disk }}
-    with:
-      network: ${{ inputs.network || vars.ZCASH_NETWORK }}
-      disk_prefix: zebrad-cache
-      disk_suffix: ${{ inputs.cached_disk_type || 'tip' }}
-      prefer_main_cached_state: ${{ inputs.prefer_main_cached_state || (github.event_name == 'push' && github.ref_name == 'main' && true) || false }}
 
   # Deploy Managed Instance Groups (MiGs) for Mainnet and Testnet,
   # with one node in the configured GCP region.
@@ -422,7 +425,7 @@ jobs:
     # When a new job is added to this workflow, add it to this list.
     needs: [ versioning, build, deploy-nodes, deploy-instance ]
     # Only open tickets for failed or cancelled jobs that are not coming from PRs.
-    # (PR statuses are already reported in the PR jobs list, and checked by Mergify.)
+    # (PR statuses are already reported in the PR jobs list, and checked by GitHub's Merge Queue.)
     if: (failure() && github.event.pull_request == null) || (cancelled() && github.event.pull_request == null)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -242,7 +242,7 @@ jobs:
     if: ${{ !cancelled() && !failure() && ((github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'release') }}
 
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
 
@@ -265,13 +265,13 @@ jobs:
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2.1.6
+        uses: google-github-actions/auth@v2.1.7
         with:
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_DEPLOYMENTS_SA }}'
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2.1.1
+        uses: google-github-actions/setup-gcloud@v2.1.2
 
       - name: Create instance template for ${{ matrix.network }}
         run: |
@@ -353,7 +353,7 @@ jobs:
     if: ${{ !failure() && github.event_name == 'workflow_dispatch' }}
 
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
 
@@ -376,13 +376,13 @@ jobs:
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2.1.6
+        uses: google-github-actions/auth@v2.1.7
         with:
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_DEPLOYMENTS_SA }}'
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2.1.1
+        uses: google-github-actions/setup-gcloud@v2.1.2
 
       # Create instance template from container image
       - name: Manual deploy of a single ${{ inputs.network }} instance running zebrad

--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -250,7 +250,7 @@ jobs:
           persist-credentials: false
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v5
         with:
           short-length: 7
 
@@ -361,7 +361,7 @@ jobs:
           persist-credentials: false
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v5
         with:
           short-length: 7
 

--- a/.github/workflows/chore-delete-gcp-resources.yml
+++ b/.github/workflows/chore-delete-gcp-resources.yml
@@ -39,20 +39,20 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2.1.6
+        uses: google-github-actions/auth@v2.1.7
         with:
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_DEPLOYMENTS_SA }}'
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2.1.1
+        uses: google-github-actions/setup-gcloud@v2.1.2
 
       # Deletes all mainnet and testnet instances older than $DELETE_INSTANCE_DAYS days.
       #
@@ -106,14 +106,14 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2.1.6
+        uses: google-github-actions/auth@v2.1.7
         with:
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_DEPLOYMENTS_SA }}'

--- a/.github/workflows/ci-build-crates.patch.yml
+++ b/.github/workflows/ci-build-crates.patch.yml
@@ -23,7 +23,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
 
       # Setup Rust with stable toolchain and minimal profile
       - name: Setup Rust

--- a/.github/workflows/ci-build-crates.yml
+++ b/.github/workflows/ci-build-crates.yml
@@ -169,7 +169,7 @@ jobs:
     # When a new job is added to this workflow, add it to this list.
     needs: [ matrix, build ]
     # Only open tickets for failed or cancelled jobs that are not coming from PRs.
-    # (PR statuses are already reported in the PR jobs list, and checked by Mergify.)
+    # (PR statuses are already reported in the PR jobs list, and checked by GitHub's Merge Queue.)
     if: (failure() && github.event.pull_request == null) || (cancelled() && github.event.pull_request == null)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-build-crates.yml
+++ b/.github/workflows/ci-build-crates.yml
@@ -60,7 +60,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
       - uses: r7kamura/rust-problem-matchers@v1.5.0
 
       # Setup Rust with stable toolchain and minimal profile
@@ -122,7 +122,7 @@ jobs:
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
       - uses: r7kamura/rust-problem-matchers@v1.5.0

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest-xl
 
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -37,7 +37,7 @@ jobs:
       rust: ${{ steps.changed-files-rust.outputs.any_changed == 'true' }}
       workflows: ${{ steps.changed-files-workflows.outputs.any_changed == 'true' }}
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -69,7 +69,7 @@ jobs:
     if: ${{ needs.changed-files.outputs.rust == 'true' }}
 
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
 
@@ -119,7 +119,7 @@ jobs:
     if: ${{ needs.changed-files.outputs.rust == 'true' }}
 
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
       - uses: r7kamura/rust-problem-matchers@v1.5.0
@@ -149,7 +149,7 @@ jobs:
     needs: changed-files
     if: ${{ needs.changed-files.outputs.workflows == 'true' }}
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
       - name: actionlint
         uses: reviewdog/action-actionlint@v1.48.0
         with:
@@ -166,7 +166,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed-files
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
       - uses: codespell-project/actions-codespell@v2.1
         with:
           only_warn: 1

--- a/.github/workflows/ci-tests.patch-external.yml
+++ b/.github/workflows/ci-tests.patch-external.yml
@@ -1,7 +1,7 @@
 # Workflow patches for skipping CI tests on PRs from external repositories
 name: Run tests
 
-# Run on PRs from external repositories, let them pass, and then Mergify will check them.
+# Run on PRs from external repositories, let them pass, and then GitHub's Merge Queue will check them.
 # GitHub doesn't support filtering workflows by source branch names, so we have to do it for each
 # job.
 on:

--- a/.github/workflows/ci-tests.patch-external.yml
+++ b/.github/workflows/ci-tests.patch-external.yml
@@ -1,5 +1,5 @@
 # Workflow patches for skipping CI tests on PRs from external repositories
-name: Run tests
+name: Run tests (skip external repos)
 
 # Run on PRs from external repositories, let them pass, and then GitHub's Merge Queue will check them.
 # GitHub doesn't support filtering workflows by source branch names, so we have to do it for each

--- a/.github/workflows/ci-tests.patch.yml
+++ b/.github/workflows/ci-tests.patch.yml
@@ -1,6 +1,6 @@
 # Workflow patches for skipping CI tests when Rust code or dependencies
 # aren't modified in a PR.
-name: Run tests
+name: Run tests (skip CI tests; no rust changes)
 
 # Run on PRs with unmodified code and dependency files.
 on:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -10,6 +10,9 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  merge_group:
+    types: [checks_requested]
+
   schedule:
     # Run this job every Friday at mid-day UTC
     # This is limited to the Zebra and lightwalletd Full Sync jobs
@@ -119,7 +122,7 @@ jobs:
   # testnet when running the image.
   build:
     name: Build images
-    # Skip PRs from external repositories, let them pass, and then Mergify will check them
+    # Skip PRs from external repositories, let them pass, and then GitHub's Merge Queue will check them
     if: ${{ !startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork }}
     uses: ./.github/workflows/sub-build-docker-image.yml
     with:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -147,9 +147,10 @@ jobs:
       image_digest: ${{ needs.build.outputs.image_digest }}
     secrets: inherit
 
+  # Disabled during `zebra-crosslink` prototyping phase to avoid GCP or Mainnet integrations
   # Runs Zebra integration tests
-  integration-tests:
-    name: Integration tests
-    needs: build
-    uses: ./.github/workflows/sub-ci-integration-tests-gcp.yml
-    secrets: inherit
+  #integration-tests:
+  #  name: Integration tests
+  #  needs: build
+  #  uses: ./.github/workflows/sub-ci-integration-tests-gcp.yml
+  #  secrets: inherit

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -13,12 +13,6 @@ on:
   merge_group:
     types: [checks_requested]
 
-  schedule:
-    # Run this job every Friday at mid-day UTC
-    # This is limited to the Zebra and lightwalletd Full Sync jobs
-    # TODO: we should move this behavior to a separate workflow
-    - cron: "0 12 * * 5"
-
   workflow_dispatch:
     inputs:
       network:

--- a/.github/workflows/ci-unit-tests-os.yml
+++ b/.github/workflows/ci-unit-tests-os.yml
@@ -14,6 +14,9 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  merge_group:
+    types: [checks_requested]
+
   workflow_dispatch:
 
   pull_request:
@@ -305,7 +308,7 @@ jobs:
     # When a new job is added to this workflow, add it to this list.
     needs: [ test,  install-from-lockfile-no-cache, check-cargo-lock, cargo-deny, unused-deps ]
     # Only open tickets for failed or cancelled jobs that are not coming from PRs.
-    # (PR statuses are already reported in the PR jobs list, and checked by Mergify.)
+    # (PR statuses are already reported in the PR jobs list, and checked by GitHub's Merge Queue.)
     if: (failure() && github.event.pull_request == null) || (cancelled() && github.event.pull_request == null)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-unit-tests-os.yml
+++ b/.github/workflows/ci-unit-tests-os.yml
@@ -94,7 +94,7 @@ jobs:
             rust: beta
 
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
       - uses: r7kamura/rust-problem-matchers@v1.5.0
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
       - uses: r7kamura/rust-problem-matchers@v1.5.0
@@ -205,7 +205,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
       - uses: r7kamura/rust-problem-matchers@v1.5.0
@@ -248,7 +248,7 @@ jobs:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
 
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
       - uses: r7kamura/rust-problem-matchers@v1.5.0
@@ -269,7 +269,7 @@ jobs:
 
     steps:
       - name: Checkout git repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
       - uses: r7kamura/rust-problem-matchers@v1.5.0

--- a/.github/workflows/docs-deploy-firebase.patch-external.yml
+++ b/.github/workflows/docs-deploy-firebase.patch-external.yml
@@ -1,7 +1,7 @@
 # Workflow patches for skipping Google Cloud docs updates on PRs from external repositories.
 name: Docs
 
-# Run on PRs from external repositories, let them pass, and then Mergify will check them.
+# Run on PRs from external repositories, let them pass, and then GitHub's Merge Queue will check them.
 # GitHub doesn't support filtering workflows by source branch names, so we have to do it for each
 # job.
 on:

--- a/.github/workflows/docs-deploy-firebase.yml
+++ b/.github/workflows/docs-deploy-firebase.yml
@@ -1,5 +1,5 @@
 # Google Cloud docs updates that run when docs, Rust code, or dependencies are modified,
-# but only on PRs from the ZcashFoundation/zebra repository. (External PRs are deployed by mergify.)
+# but only on PRs from the ZcashFoundation/zebra repository. (External PRs are deployed by GitHub's Merge Queue.)
 
 # - Builds and deploys Zebra Book Docs using mdBook, setting up necessary tools and deploying to Firebase.
 # - Compiles and deploys external documentation, setting up Rust with the beta toolchain and default profile, building the docs, and deploying them to Firebase.
@@ -74,7 +74,7 @@ env:
 jobs:
   build-docs-book:
     name: Build and Deploy Zebra Book Docs
-    # Skip PRs from external repositories, let them pass, and then Mergify will check them
+    # Skip PRs from external repositories, let them pass, and then GitHub's Merge Queue will check them
     if: ${{ !startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork }}
     timeout-minutes: 5
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-deploy-firebase.yml
+++ b/.github/workflows/docs-deploy-firebase.yml
@@ -85,14 +85,14 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
 
       - uses: r7kamura/rust-problem-matchers@v1.5.0
 
       - name: Setup mdBook
-        uses: jontze/action-mdbook@v3.0.0
+        uses: jontze/action-mdbook@v3.0.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           mdbook-version: '~0.4'
@@ -106,7 +106,7 @@ jobs:
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2.1.6
+        uses: google-github-actions/auth@v2.1.7
         with:
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_FIREBASE_SA }}'
@@ -138,7 +138,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
 
@@ -164,7 +164,7 @@ jobs:
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2.1.6
+        uses: google-github-actions/auth@v2.1.7
         with:
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_FIREBASE_SA }}'

--- a/.github/workflows/docs-dockerhub-description.yml
+++ b/.github/workflows/docs-dockerhub-description.yml
@@ -17,7 +17,7 @@ jobs:
   dockerHubDescription:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/manual-zcashd-deploy.yml
+++ b/.github/workflows/manual-zcashd-deploy.yml
@@ -34,7 +34,7 @@ jobs:
           persist-credentials: false
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v5
         with:
           short-length: 7
 

--- a/.github/workflows/manual-zcashd-deploy.yml
+++ b/.github/workflows/manual-zcashd-deploy.yml
@@ -29,7 +29,7 @@ jobs:
       id-token: 'write'
 
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
 
@@ -52,13 +52,13 @@ jobs:
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2.1.6
+        uses: google-github-actions/auth@v2.1.7
         with:
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_DEPLOYMENTS_SA }}'
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2.1.1
+        uses: google-github-actions/setup-gcloud@v2.1.2
 
       # Create instance template from container image
       - name: Create instance template

--- a/.github/workflows/release-crates-io.yml
+++ b/.github/workflows/release-crates-io.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: r7kamura/rust-problem-matchers@v1.5.0
 
       - name: Checkout git repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/release-crates-io.yml
+++ b/.github/workflows/release-crates-io.yml
@@ -112,7 +112,7 @@ jobs:
     # When a new job is added to this workflow, add it to this list.
     needs: [ check-release ]
     # Only open tickets for failed or cancelled jobs that are not coming from PRs.
-    # (PR statuses are already reported in the PR jobs list, and checked by Mergify.)
+    # (PR statuses are already reported in the PR jobs list, and checked by GitHub's Merge Queue.)
     if: (failure() && github.event.pull_request == null) || (cancelled() && github.event.pull_request == null)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-crates-io.yml
+++ b/.github/workflows/release-crates-io.yml
@@ -75,7 +75,7 @@ jobs:
           persist-credentials: false
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v5
         with:
           short-length: 7
 

--- a/.github/workflows/sub-build-docker-image.yml
+++ b/.github/workflows/sub-build-docker-image.yml
@@ -86,7 +86,7 @@ jobs:
       - uses: r7kamura/rust-problem-matchers@v1.5.0
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v5
         with:
           short-length: 7
 

--- a/.github/workflows/sub-build-docker-image.yml
+++ b/.github/workflows/sub-build-docker-image.yml
@@ -80,7 +80,7 @@ jobs:
     env:
       DOCKER_BUILD_SUMMARY: ${{ vars.DOCKER_BUILD_SUMMARY }}
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
       - uses: r7kamura/rust-problem-matchers@v1.5.0
@@ -126,7 +126,7 @@ jobs:
 
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2.1.6
+        uses: google-github-actions/auth@v2.1.7
         with:
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_ARTIFACTS_SA }}'
@@ -193,7 +193,7 @@ jobs:
         # - `dev` for a pull request event
       - name: Docker Scout
         id: docker-scout
-        uses: docker/scout-action@v1.14.0
+        uses: docker/scout-action@v1.15.0
         # We only run Docker Scout on the `runtime` target, as the other targets are not meant to be released
         # and are commonly used for testing, and thus are ephemeral.
         # TODO: Remove the `contains` check once we have a better way to determine if just new vulnerabilities are present.

--- a/.github/workflows/sub-ci-integration-tests-gcp.yml
+++ b/.github/workflows/sub-ci-integration-tests-gcp.yml
@@ -1,5 +1,5 @@
 # Google Cloud integration tests that run when Rust code or dependencies are modified,
-# but only on PRs from the ZcashFoundation/zebra repository. (External PRs are tested by mergify.)
+# but only on PRs from the ZcashFoundation/zebra repository. (External PRs are tested by GitHub's Merge Queue.)
 #
 # Specific conditions and dependencies are set for each job to ensure they are executed in the correct sequence and under the right circumstances.
 # Each test has a description of the conditions under which it runs.
@@ -36,10 +36,6 @@ on:
 #! `sub-deploy-integration-tests-gcp.yml` workflow file as inputs. If modified in this file, they must
 #! also be updated in the `sub-deploy-integration-tests-gcp.yml` file.
 jobs:
-  # to also run a job on Mergify head branches,
-  # add `|| (github.event_name == 'push' && startsWith(github.head_ref, 'mergify/merge-queue/'))`:
-  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-based-on-the-head-or-base-branch-of-a-pull-request-1
-
   # Check if the cached state disks used by the tests are available for the default network.
   #
   # The default network is mainnet unless a manually triggered workflow or repository variable
@@ -48,7 +44,7 @@ jobs:
   # The outputs for this job have the same names as the workflow outputs in sub-find-cached-disks.yml
   get-available-disks:
     name: Check if cached state disks exist for ${{ inputs.network || vars.ZCASH_NETWORK }}
-    # Skip PRs from external repositories, let them pass, and then Mergify will check them
+    # Skip PRs from external repositories, let them pass, and then GitHub's Merge Queue will check them
     if: ${{ !startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork }}
     uses: ./.github/workflows/sub-find-cached-disks.yml
     with:
@@ -554,7 +550,7 @@ jobs:
         scan-task-commands-test,
       ]
     # Only open tickets for failed scheduled jobs, manual workflow runs, or `main` branch merges.
-    # (PR statuses are already reported in the PR jobs list, and checked by Mergify.)
+    # (PR statuses are already reported in the PR jobs list, and checked by GitHub's Merge Queue.)
     if: (failure() && github.event.pull_request == null) || (cancelled() && github.event.pull_request == null)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sub-ci-unit-tests-docker.yml
+++ b/.github/workflows/sub-ci-unit-tests-docker.yml
@@ -1,5 +1,5 @@
 # Google Cloud unit tests that run when Rust code or dependencies are modified,
-# but only on PRs from the ZcashFoundation/zebra repository. (External PRs are tested by mergify.)
+# but only on PRs from the ZcashFoundation/zebra repository. (External PRs are tested by GitHub's Merge Queue.)
 #
 # This workflow is designed for running various unit tests within Docker containers.
 # Jobs:
@@ -183,7 +183,7 @@ jobs:
     # Testnet jobs are not in this list, because we expect testnet to fail occasionally.
     needs: [ test-all, test-fake-activation-heights, test-empty-sync, test-lightwalletd-integration, test-configuration-file, test-zebra-conf-path ]
     # Only open tickets for failed scheduled jobs, manual workflow runs, or `main` branch merges.
-    # (PR statuses are already reported in the PR jobs list, and checked by Mergify.)
+    # (PR statuses are already reported in the PR jobs list, and checked by GitHub's Merge Queue.)
     # TODO: if a job times out, we want to create a ticket. Does failure() do that? Or do we need cancelled()?
     if: failure() && github.event.pull_request == null
     runs-on: ubuntu-latest

--- a/.github/workflows/sub-ci-unit-tests-docker.yml
+++ b/.github/workflows/sub-ci-unit-tests-docker.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: r7kamura/rust-problem-matchers@v1.5.0
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v5
         with:
           short-length: 7
 
@@ -89,7 +89,7 @@ jobs:
       - uses: r7kamura/rust-problem-matchers@v1.5.0
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v5
         with:
           short-length: 7
 
@@ -109,7 +109,7 @@ jobs:
       - uses: r7kamura/rust-problem-matchers@v1.5.0
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v5
         with:
           short-length: 7
 
@@ -129,7 +129,7 @@ jobs:
       - uses: r7kamura/rust-problem-matchers@v1.5.0
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v5
         with:
           short-length: 7
 

--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -147,7 +147,7 @@ jobs:
       - uses: r7kamura/rust-problem-matchers@v1.5.0
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v5
         with:
           short-length: 7
 
@@ -392,7 +392,7 @@ jobs:
       - uses: r7kamura/rust-problem-matchers@v1.5.0
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v5
         with:
           short-length: 7
 
@@ -688,7 +688,7 @@ jobs:
       - uses: r7kamura/rust-problem-matchers@v1.5.0
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v5
         with:
           short-length: 7
 

--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -140,7 +140,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
           fetch-depth: '2'
@@ -172,13 +172,13 @@ jobs:
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2.1.6
+        uses: google-github-actions/auth@v2.1.7
         with:
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_DEPLOYMENTS_SA }}'
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2.1.1
+        uses: google-github-actions/setup-gcloud@v2.1.2
 
       # Create a Compute Engine virtual machine and attach a cached state disk using the
       # $CACHED_DISK_NAME env as the source image to populate the disk cached state
@@ -390,7 +390,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
           fetch-depth: '2'
@@ -434,13 +434,13 @@ jobs:
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2.1.6
+        uses: google-github-actions/auth@v2.1.7
         with:
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_DEPLOYMENTS_SA }}'
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2.1.1
+        uses: google-github-actions/setup-gcloud@v2.1.2
 
       # Sets the $UPDATE_SUFFIX env var to "-u" if updating a previous cached state,
       # and the empty string otherwise.
@@ -688,7 +688,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
           fetch-depth: '2'
@@ -702,13 +702,13 @@ jobs:
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2.1.6
+        uses: google-github-actions/auth@v2.1.7
         with:
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_DEPLOYMENTS_SA }}'
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2.1.1
+        uses: google-github-actions/setup-gcloud@v2.1.2
 
       # Deletes the instances that has been recently deployed in the actual commit after all
       # previous jobs have run, no matter the outcome of the job.

--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -503,18 +503,19 @@ jobs:
           )
 
           if [[ -z "$INITIAL_DISK_DB_VERSION" ]]; then
+          # Check for new database creation
+          if echo "$DOCKER_LOGS" | grep -q "creating.new.database"; then
+              INITIAL_DISK_DB_VERSION="new"
+          else
               echo "Checked logs:"
               echo ""
               echo "$DOCKER_LOGS"
               echo ""
-              echo "Missing initial disk database version in logs: $INITIAL_DISK_DB_VERSION"
+              echo "Missing initial disk database version in logs"
               # Fail the tests, because Zebra didn't log the initial disk database version,
               # or the regex in this step is wrong.
-              false
+              exit 1
           fi
-
-          if [[ "$INITIAL_DISK_DB_VERSION" = "creating.new.database" ]]; then
-              INITIAL_DISK_DB_VERSION="new"
           else
               INITIAL_DISK_DB_VERSION="v${INITIAL_DISK_DB_VERSION//./-}"
           fi
@@ -538,7 +539,7 @@ jobs:
               echo "Missing running database version in logs: $RUNNING_DB_VERSION"
               # Fail the tests, because Zebra didn't log the running database version,
               # or the regex in this step is wrong.
-              false
+              exit 1
           fi
 
           RUNNING_DB_VERSION="v${RUNNING_DB_VERSION//./-}"

--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -185,7 +185,6 @@ jobs:
       # if the test needs it.
       - name: Create ${{ inputs.test_id }} GCP compute instance
         id: create-instance
-        shell: /usr/bin/bash -x {0}
         run: |
           NAME="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}"
           DISK_PARAMS="size=400GB,type=pd-balanced,name=${NAME},device-name=${NAME}"
@@ -256,7 +255,6 @@ jobs:
       # are only used to match those variables paths.
       - name: Launch ${{ inputs.test_id }} test
         id: launch-test
-        shell: /usr/bin/bash -x {0}
         run: |
           gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --zone ${{ vars.GCP_ZONE }} \
@@ -288,7 +286,6 @@ jobs:
       # Show debug logs if previous job failed
       - name: Show debug logs if previous job failed
         if: ${{ failure() }}
-        shell: /usr/bin/bash -x {0}
         run: |
           gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --zone ${{ vars.GCP_ZONE }} \
@@ -315,7 +312,6 @@ jobs:
       #
       # Errors in the tests are caught by the final test status job.
       - name: Check startup logs for ${{ inputs.test_id }}
-        shell: /usr/bin/bash -x {0}
         run: |
           gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --zone ${{ vars.GCP_ZONE }} \
@@ -344,7 +340,6 @@ jobs:
       # with that status.
       # (`docker wait` can also wait for multiple containers, but we only ever wait for a single container.)
       - name: Result of ${{ inputs.test_id }} test
-        shell: /usr/bin/bash -x {0}
         run: |
           gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --zone ${{ vars.GCP_ZONE }} \
@@ -477,7 +472,6 @@ jobs:
       # Passes the versions to subsequent steps using the $INITIAL_DISK_DB_VERSION,
       # $RUNNING_DB_VERSION, and $DB_VERSION_SUMMARY env variables.
       - name: Get database versions from logs
-        shell: /usr/bin/bash -x {0}
         run: |
           INITIAL_DISK_DB_VERSION=""
           RUNNING_DB_VERSION=""
@@ -568,7 +562,6 @@ jobs:
       #
       # Passes the sync height to subsequent steps using the $SYNC_HEIGHT env variable.
       - name: Get sync height from logs
-        shell: /usr/bin/bash -x {0}
         run: |
           SYNC_HEIGHT=""
 

--- a/.github/workflows/sub-find-cached-disks.yml
+++ b/.github/workflows/sub-find-cached-disks.yml
@@ -58,7 +58,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -66,13 +66,13 @@ jobs:
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2.1.6
+        uses: google-github-actions/auth@v2.1.7
         with:
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_DEPLOYMENTS_SA }}'
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2.1.1
+        uses: google-github-actions/setup-gcloud@v2.1.2
 
       # Performs formatting on disk name components.
       #

--- a/.github/workflows/sub-test-zebra-config.yml
+++ b/.github/workflows/sub-test-zebra-config.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest-m
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/sub-test-zebra-config.yml
+++ b/.github/workflows/sub-test-zebra-config.yml
@@ -43,7 +43,7 @@ jobs:
           persist-credentials: false
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v5
         with:
           short-length: 7
 

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -163,6 +163,12 @@ impl From<ConsensusBranchId> for u32 {
     }
 }
 
+impl From<u32> for ConsensusBranchId {
+    fn from(branch: u32) -> Self {
+        ConsensusBranchId(branch)
+    }
+}
+
 impl ToHex for &ConsensusBranchId {
     fn encode_hex<T: FromIterator<char>>(&self) -> T {
         self.bytes_in_display_order().encode_hex()

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1510,11 +1510,23 @@ pub struct AddressBalance {
 
 /// A hex-encoded [`ConsensusBranchId`] string.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
-struct ConsensusBranchIdHex(#[serde(with = "hex")] ConsensusBranchId);
+pub struct ConsensusBranchIdHex(#[serde(with = "hex")] ConsensusBranchId);
+
+impl ConsensusBranchIdHex {
+    /// Returns a new instance of ['ConsensusBranchIdHex'].
+    pub fn new(consensus_branch_id: u32) -> Self {
+        ConsensusBranchIdHex(consensus_branch_id.into())
+    }
+
+    /// Returns the value of the ['ConsensusBranchId'].
+    pub fn inner(&self) -> u32 {
+        self.0.into()
+    }
+}
 
 /// Information about [`NetworkUpgrade`] activation.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
-struct NetworkUpgradeInfo {
+pub struct NetworkUpgradeInfo {
     /// Name of upgrade, string.
     ///
     /// Ignored by lightwalletd, but useful for debugging.
@@ -1528,9 +1540,29 @@ struct NetworkUpgradeInfo {
     status: NetworkUpgradeStatus,
 }
 
+impl NetworkUpgradeInfo {
+    /// Constructs [`NetworkUpgradeInfo`] from its constituent parts.
+    pub fn from_parts(
+        name: NetworkUpgrade,
+        activation_height: Height,
+        status: NetworkUpgradeStatus,
+    ) -> Self {
+        Self {
+            name,
+            activation_height,
+            status,
+        }
+    }
+
+    /// Returns the contents of ['NetworkUpgradeInfo'].
+    pub fn into_parts(self) -> (NetworkUpgrade, Height, NetworkUpgradeStatus) {
+        (self.name, self.activation_height, self.status)
+    }
+}
+
 /// The activation status of a [`NetworkUpgrade`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
-enum NetworkUpgradeStatus {
+pub enum NetworkUpgradeStatus {
     /// The network upgrade is currently active.
     ///
     /// Includes all network upgrades that have previously activated,
@@ -1551,7 +1583,7 @@ enum NetworkUpgradeStatus {
 ///
 /// These branch IDs are different when the next block is a network upgrade activation block.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
-struct TipConsensusBranch {
+pub struct TipConsensusBranch {
     /// Branch ID used to validate the current chain tip, big-endian, hex-encoded.
     #[serde(rename = "chaintip")]
     chain_tip: ConsensusBranchIdHex,
@@ -1559,6 +1591,21 @@ struct TipConsensusBranch {
     /// Branch ID used to validate the next block, big-endian, hex-encoded.
     #[serde(rename = "nextblock")]
     next_block: ConsensusBranchIdHex,
+}
+
+impl TipConsensusBranch {
+    /// Constructs [`TipConsensusBranch`] from its constituent parts.
+    pub fn from_parts(chain_tip: u32, next_block: u32) -> Self {
+        Self {
+            chain_tip: ConsensusBranchIdHex::new(chain_tip),
+            next_block: ConsensusBranchIdHex::new(next_block),
+        }
+    }
+
+    /// Returns the contents of ['TipConsensusBranch'].
+    pub fn into_parts(self) -> (u32, u32) {
+        (self.chain_tip.inner(), self.next_block.inner())
+    }
 }
 
 /// Response to a `sendrawtransaction` RPC request.
@@ -1790,6 +1837,26 @@ impl Default for GetBlockTrees {
             sapling: SaplingTrees { size: 0 },
             orchard: OrchardTrees { size: 0 },
         }
+    }
+}
+
+impl GetBlockTrees {
+    /// Constructs a new instance of ['GetBlockTrees'].
+    pub fn new(sapling: u64, orchard: u64) -> Self {
+        GetBlockTrees {
+            sapling: SaplingTrees { size: sapling },
+            orchard: OrchardTrees { size: orchard },
+        }
+    }
+
+    /// Returns sapling data held by ['GetBlockTrees'].
+    pub fn sapling(self) -> u64 {
+        self.sapling.size
+    }
+
+    /// Returns orchard data held by ['GetBlockTrees'].
+    pub fn orchard(self) -> u64 {
+        self.orchard.size
     }
 }
 

--- a/zebra-rpc/src/methods/trees.rs
+++ b/zebra-rpc/src/methods/trees.rs
@@ -105,6 +105,19 @@ impl GetTreestate {
             orchard,
         }
     }
+
+    /// Returns the contents of ['GetTreeState'].
+    pub fn into_parts(self) -> (Hash, Height, u32, Option<Vec<u8>>, Option<Vec<u8>>) {
+        (
+            self.hash,
+            self.height,
+            self.time,
+            self.sapling
+                .map(|treestate| treestate.commitments.final_state),
+            self.orchard
+                .map(|treestate| treestate.commitments.final_state),
+        )
+    }
 }
 
 impl Default for GetTreestate {
@@ -123,10 +136,22 @@ impl Default for GetTreestate {
 ///
 /// [1]: https://zcash.github.io/rpc/z_gettreestate.html
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
-struct Treestate<Tree: AsRef<[u8]>> {
+pub struct Treestate<Tree: AsRef<[u8]>> {
     /// Contains an Orchard or Sapling serialized note commitment tree,
     /// hex-encoded.
     commitments: Commitments<Tree>,
+}
+
+impl<Tree: AsRef<[u8]>> Treestate<Tree> {
+    /// Returns a new instance of ['Treestate'].
+    pub fn new(commitments: Commitments<Tree>) -> Self {
+        Treestate { commitments }
+    }
+
+    /// Returns a reference to the commitments.
+    pub fn inner(&self) -> &Commitments<Tree> {
+        &self.commitments
+    }
 }
 
 /// A wrapper that contains either an Orchard or Sapling note commitment tree.
@@ -136,9 +161,21 @@ struct Treestate<Tree: AsRef<[u8]>> {
 ///
 /// [1]: https://zcash.github.io/rpc/z_gettreestate.html
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
-struct Commitments<Tree: AsRef<[u8]>> {
+pub struct Commitments<Tree: AsRef<[u8]>> {
     /// Orchard or Sapling serialized note commitment tree, hex-encoded.
     #[serde(with = "hex")]
     #[serde(rename = "finalState")]
     final_state: Tree,
+}
+
+impl<Tree: AsRef<[u8]>> Commitments<Tree> {
+    /// Returns a new instance of ['Commitments'].
+    pub fn new(final_state: Tree) -> Self {
+        Commitments { final_state }
+    }
+
+    /// Returns a reference to the final_state.
+    pub fn inner(&self) -> &Tree {
+        &self.final_state
+    }
 }


### PR DESCRIPTION
## Motivation

During the prototyping phase of `zebra-crosslink`, we disable integration tests because we know we cannot/should not connect to mainnet.

This means we are also disabling other integration tests, such as `lightwalletd` integration tests. Once the core node prototype is functional, we need a phase to re-enable integration testing for a broader swath of components, and in particular we need to ensure lightwalletd and existing wallets can function with only absolutely necessary backwards-incompatible changes.

A more practical motivation is that we want to reduce resource costs until the prototype is more mature.

### Specifications & References

None

## Solution

This PR simply hacks out _some_ of the upstream integration test code as well as scheduled runs. It does not thoroughly remove all of the associated yml files, since we anticipate re-enabling the full CI/CD pipeline as Crosslink matures.

### Tests

This is tested by manually dispatching the workflow and verifying everything succeeds against this branch.

### Follow-up Work

- Add a ticket to re-enable non-Mainnet integration tests, especially for lightwalletd.
- Add a ticket to enable live/persistent Testnet integration tests in place of the former Mainnet tests.
- Add a ticket to track activation/sync validation prior to merging upstream. (Is there a way to test that Mainnet syncs work prior to activation on Mainnet besides running similar tests against live Testnet?)

### PR Author's Checklist

- [ ] The PR name will make sense to ~~users~~ _developers_.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested by manual dispatch of the Github action.
- [ ] The documentation is up to date.
- [ ] ~~The PR has a priority label.~~

### PR Reviewer's Checklist

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.